### PR TITLE
Fix date discovery bug

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Github actions will only fetch the latest commit by default, causing a bug where each automated workflow overwrites the discovered date to the most recent commit (instead of capturing the oldest commit where the file was found).

This change adds a setting to pull all commits and write the correct date.